### PR TITLE
fix(inverted-ternary): invert option in example

### DIFF
--- a/parameters/query.md
+++ b/parameters/query.md
@@ -56,7 +56,9 @@ import type { Query } from '@kitajs/runtime';
 
 // /?option=true
 export function get(option: Query<boolean>) {
-  return option ? "You didn't select the option" : 'You selected the option';
+  return option
+    ? 'You have selected the option'
+    : "You haven't selected the option";
 }
 ```
 


### PR DESCRIPTION
It looks as though there is an inverted ternary here, as `/?option=true` seems to imply you haven't selected the option.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
