### PR TITLE
fix(error-comment): changed contradictory code comment and error message

### DIFF
--- a/parameters/http-errors.md
+++ b/parameters/http-errors.md
@@ -98,7 +98,6 @@ import type { HttpErrors } from '@fastify/sensible';
 
 export function get(errors: HttpErrors) {
   if (somethingWentWrong) {
-    // This error will be captured by Kita
     throw new Error('This error will NOT be captured by Kita');
   }
 

--- a/parameters/http-errors.md
+++ b/parameters/http-errors.md
@@ -98,6 +98,7 @@ import type { HttpErrors } from '@fastify/sensible';
 
 export function get(errors: HttpErrors) {
   if (somethingWentWrong) {
+  // This error will NOT be captured by Kita
     throw new Error('This error will NOT be captured by Kita');
   }
 


### PR DESCRIPTION
It looks as though the comment and error message are contradicting themselves here:
```
  if (somethingWentWrong) {
    // This error will be captured by Kita
    throw new Error('This error will NOT be captured by Kita');
  }
```

According to my understanding from the docs, this error should be captured by Kita and this PR treats it likewise.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
