### PR TITLE
fix(method-example-names): GET -> POST, POST -> PUT on example

### DIFF
--- a/concepts/exposing-types.md
+++ b/concepts/exposing-types.md
@@ -15,7 +15,7 @@ Consider these two example routes:
 
 ::: code-group
 
-```ts {3} [GET]
+```ts {3} [POST]
 import type { Body } from '@kitajs/runtime';
 
 interface PostBody {
@@ -27,7 +27,7 @@ export function post(content: Body<PostBody>) {
 }
 ```
 
-```ts {3} [POST]
+```ts {3} [PUT]
 import type { Body } from '@kitajs/runtime';
 
 export interface PutBody {


### PR DESCRIPTION
GET was being used to describe a POST request, and POST used to describe a PUT request.

<!--
Thank you for your pull request. Please provide a description above and review the requirements below.

Bug fixes and new features should include tests.

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
